### PR TITLE
Fix deprecated handle check

### DIFF
--- a/scripting/nt_warmup_lite.sp
+++ b/scripting/nt_warmup_lite.sp
@@ -9,14 +9,14 @@ public Plugin myinfo = {
     name = "NT Warmup Lite",
     author = "Agiel, soft as HELL, edits by bauxite",
     description = "Enables TDM warmup on map start",
-    version = "0.1.0",
+    version = "0.1.1",
     url = "https://github.com/bauxiteDYS/SM-NT-Warmup-Lite"
 };
 
 ConVar cWarmupEnabled; 
 ConVar cWarmupTimelimit;
 ConVar cRestartCommand;
-Handle hWarmupTimer;
+Handle hWarmupTimer = INVALID_HANDLE;
 bool bCanEnable;
 
 public void OnPluginStart()
@@ -52,7 +52,7 @@ void StartWarmup()
 	
 	PrintToChatAll("Warmup started!");
 	
-	if(!IsValidHandle(hWarmupTimer))
+	if(hWarmupTimer == INVALID_HANDLE)
 	{
 		hWarmupTimer = CreateTimer(timeLimit, timer_EndWarmup, _, TIMER_FLAG_NO_MAPCHANGE);
 	}
@@ -60,6 +60,8 @@ void StartWarmup()
 
 public Action timer_EndWarmup(Handle timer)
 {
+	hWarmupTimer = INVALID_HANDLE;
+	
 	for(int i = 1; i <= MaxClients; i++)
 	{
 		if(!IsClientInGame(i))

--- a/scripting/nt_warmup_lite.sp
+++ b/scripting/nt_warmup_lite.sp
@@ -32,6 +32,11 @@ public void OnMapInit()
 	bCanEnable = true;
 }
 
+public void OnMapEnd()
+{
+	hWarmupTimer = INVALID_HANDLE;
+}
+
 public void OnConfigsExecuted()
 {
 	if(!bCanEnable)


### PR DESCRIPTION
The `IsValidHandle` function is deprecated, and should typically not be used. Instead, the handle should be managed manually.

This change refactors the code to manually assign a default `INVALID_HANDLE` value, and to check against that value, instead.

We also manually invalidate `hWarmupTimer` at `OnMapEnd`, because even through `CreateTimer` has the `TIMER_FLAG_NO_MAPCHANGE` flag set, that will only close the underlying Timer handle which `hWarmupTimer` represents, but it won't automatically change the actual `hWarmupTimer` value back to `INVALID_HANDLE`.

For more info on the `IsValidHandle` deprecation, see:
https://github.com/alliedmodders/sourcemod/blob/512e7c37c10d8040e8ee7d914a51627295a8c5b0/plugins/include/handles.inc#L111-L128